### PR TITLE
Key FromStr instead of necessarily String

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,22 @@
 //! strfmt crate
 
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write;
-use std::collections::HashMap;
 use std::string::String;
 
+mod fmtstr;
+mod formatter;
 #[cfg(test)]
 mod tests;
 mod types;
-mod formatter;
-mod fmtstr;
 
 #[macro_use]
 mod fmtnum;
 
-pub use types::{Result, FmtError, Alignment, Sign};
 pub use fmtstr::strfmt_map;
 pub use formatter::Formatter;
+pub use types::{Alignment, FmtError, Result, Sign};
 
 // u128 & i128 unstable (see https://github.com/rust-lang/rust/issues/35118)
 fmtint!(u8 i8 u16 i16 u32 i32 u64 i64 usize isize);
@@ -31,7 +31,7 @@ pub fn strfmt<T: fmt::Display>(fmtstr: &str, vars: &HashMap<String, T>) -> Resul
                 let mut msg = String::new();
                 write!(msg, "Invalid key: {}", fmt.key).unwrap();
                 return Err(FmtError::KeyError(msg));
-            },
+            }
         };
         fmt.str(v.to_string().as_str())
     };

--- a/src/tests/key.rs
+++ b/src/tests/key.rs
@@ -1,0 +1,76 @@
+//! Test keys other than String.
+
+use super::super::*;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+#[test]
+fn test_key_u32() {
+    let mut vars: HashMap<u32, String> = HashMap::new();
+    vars.insert(0, "X".to_string());
+
+    assert_eq!("hi {0}".format(&vars).unwrap(), "hi X");
+    assert_eq!("hi {0}".to_string().format(&vars).unwrap(), "hi X");
+    assert_eq!(
+        "hi {1}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: 1".into()))
+    );
+    assert_eq!(
+        "hi {you}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: you".into()))
+    );
+}
+
+#[test]
+fn test_key_i32() {
+    let mut vars: HashMap<i32, String> = HashMap::new();
+    vars.insert(-1, "X".to_string());
+
+    assert_eq!("hi {-1}".format(&vars).unwrap(), "hi X");
+    assert_eq!("hi {-1}".to_string().format(&vars).unwrap(), "hi X");
+    assert_eq!(
+        "hi {1}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: 1".into()))
+    );
+    assert_eq!(
+        "hi {you}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: you".into()))
+    );
+}
+
+#[derive(PartialEq, Eq, Hash)]
+enum Key {
+    Zero,
+    One,
+    Two,
+}
+
+impl FromStr for Key {
+    type Err = FmtError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "Zero" => Ok(Key::Zero),
+            "One" => Ok(Key::One),
+            "Two" => Ok(Key::Two),
+            _ => Err(FmtError::KeyError(s.to_string())),
+        }
+    }
+}
+
+#[test]
+fn test_key_enum() {
+    let mut vars: HashMap<Key, String> = HashMap::new();
+    vars.insert(Key::Zero, "X".to_string());
+
+    assert_eq!("hi {Zero}".format(&vars).unwrap(), "hi X");
+    assert_eq!("hi {Zero}".to_string().format(&vars).unwrap(), "hi X");
+    assert_eq!(
+        "hi {One}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: One".into()))
+    );
+    assert_eq!(
+        "hi {you}".format(&vars),
+        Err(FmtError::KeyError("Invalid key: you".into()))
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod fmt;
+mod key;
 mod strfmt;
 mod test_trait;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,7 +2,7 @@ mod fmt;
 mod strfmt;
 mod test_trait;
 
-use super::{FmtError};
+use super::FmtError;
 
 #[test]
 fn test_error() {


### PR DESCRIPTION
I switched the String as key of HashMap to a type implementing Hash + Eq + FromStr. String can still be used as before and all the old tests still pass without modification. Tests using i32, u32, and an enum have been added.

A FmtError::KeyError is returned if the identifier from the format text cannot be converted to the specified key. This is the same as if the key was not present. That makes sense for my use case and prevents needing to change the FmtError type. It may be worth the change in future if other users of the library want to distinguishing between the two causes.

Using an enum is my use case that prompted the change. It both improves performance and fits into the rest of the code for that project better.