### PR TITLE
Correct default alignment for strings

### DIFF
--- a/src/fmtnum.rs
+++ b/src/fmtnum.rs
@@ -3,6 +3,8 @@ macro_rules! fmtint {
         #[allow(unused_comparisons)]
         impl<'a, 'b> Formatter<'a, 'b> {
             pub fn $t(&mut self, x: $t) -> Result<()> {
+                self.set_default_align(Alignment::Right);
+
                 let ty = match self.ty() {
                     None => ' ',
                     Some(c) => c,
@@ -63,6 +65,8 @@ macro_rules! fmtfloat {
     ($($t:ident)*) => ($(
         impl<'a, 'b> Formatter<'a, 'b> {
             pub fn $t(&mut self, x: $t) -> Result<()> {
+                self.set_default_align(Alignment::Right);
+
                 let ty = match self.ty() {
                     None => 'f',
                     Some(c) => c,

--- a/src/fmtstr.rs
+++ b/src/fmtstr.rs
@@ -70,6 +70,7 @@ fn write_from<I>(fmt: &mut Formatter, f: I, n: usize) -> usize
 impl<'a, 'b> Formatter<'a, 'b> {
     /// format the given string onto the buffer
     pub fn str(&mut self, s: &str) -> Result<()> {
+        self.set_default_align(Alignment::Left);
         if !(self.ty() == None || self.ty() == Some('s')) {
             let mut msg = String::new();
             write!(msg, "Unknown format code {:?} for object of type 'str'", self.ty()).unwrap();
@@ -127,6 +128,7 @@ impl<'a, 'b> Formatter<'a, 'b> {
                     }
                     Alignment::Equal => return Err(FmtError::Invalid(
                         "sign aware zero padding and Align '=' not yet supported".to_string())),
+                    Alignment::Unspecified => unreachable!(),
                 }
             }
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -10,7 +10,7 @@ use types::*;
 pub struct Formatter<'a, 'b> {
     pub key: &'a str,
     fill: char,
-    align: Alignment, // default Right
+    align: Alignment, // default Right for numbers, Left for strings
     sign: Sign,
     alternate: bool,
     width: Option<usize>,
@@ -100,7 +100,7 @@ fn parse_like_python(rest: &str) -> Result<FmtPy> {
 
     let mut format = FmtPy {
         fill: ' ',
-        align: '>',
+        align: '\0',
         alternate: false,
         sign: '\0',
         width: -1,
@@ -284,6 +284,7 @@ impl<'a, 'b> Formatter<'a, 'b> {
             key: identifier,
             fill: format.fill,
             align: match format.align {
+                '\0' => Alignment::Unspecified,
                 '<' => Alignment::Left,
                 '^' => Alignment::Center,
                 '>' => Alignment::Right,
@@ -334,6 +335,13 @@ impl<'a, 'b> Formatter<'a, 'b> {
     /// align getter
     pub fn align(&self) -> Alignment {
         self.align.clone()
+    }
+
+    // provide default for unspecified alignment
+    pub fn set_default_align(&mut self, align: Alignment) {
+        if self.align == Alignment::Unspecified {
+            self.align = align
+        }
     }
 
     /// width getter

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -66,7 +66,7 @@ fn test_values() {
         // simple positioning
         ("{x}", "X", 0),
         ("{x:}", "X", 0),
-        ("{x:3}", "  X", 0),
+        ("{x:3}", "X  ", 0),
         ("{x:>3}", "  X", 0),
         ("{x:<3}", "X  ", 0),
         ("{x:^3}", " X ", 0),
@@ -77,12 +77,16 @@ fn test_values() {
         (" hi {x:^4}-you rock", " hi  X  -you rock", 0),
 
         // fill confusion
-        ("{x:10}", "         X", 0),
+        ("{x:10}", "X         ", 0),
+        ("{x:>10}", "         X", 0),
+        ("{x:0<5}", "X0000", 0),
+        ("{x:0>5}", "0000X", 0),
         ("{long:.3}", "too", 0),
-        ("{long:<5.3}", "too  ", 0),
-        ("{long:5.3}", "  too", 0),
+        ("{long:5.3}", "too  ", 0),
+        ("{long:>5.3}", "  too", 0),
         ("{long:5.7}", "toooloo", 0),
         ("{long:<5.7}", "toooloo", 0),
+        ("{long:>5.7}", "toooloo", 0),
         ("{long:^5.7}", "toooloo", 0),
         ("{long:<}", &too_long, 0),
         ("{long:<<}", &too_long, 0),
@@ -130,6 +134,10 @@ fn test_values() {
         ("{x:<4d}", "", 3),
         ("{x:,}", "", 3),
         ("{x:<-10}", "", 3),
+
+        // TODO
+        ("{x:0=5}", "00X00", 1),
+        ("{x:03}", "00X", 1),
     ];
 
     run_tests(&values, &vars, &strfmt);

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,9 +6,10 @@ use std::result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Alignment {
+    Unspecified, // default Left for strings, Right for numbers
     Left,
     Center,
-    Right, // default
+    Right,
     Equal,
 }
 


### PR DESCRIPTION
https://doc.rust-lang.org/std/fmt/#width specifies default left-align for strings, right-align for numbers. This library used default right-align for everything. Update it to default left-align strings.

Fixes #19.