### PR TITLE
strfmt generic over Map trait instead of HashMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub trait Map {
    fn get_map(&self, k: &Self::Key) -> Option<Self::Out>;
 }
 
-impl<'b, K: Eq + Hash, T> Map for &'b HashMap<K, T> {
+impl<'b, K: Eq + Hash, T, S: std::hash::BuildHasher> Map for &'b HashMap<K, T, S> {
    type Key = K;
    type Out = &'b T;
    fn get_map(&self, k: &Self::Key) -> Option<Self::Out>{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! strfmt crate
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fmt::Write;
 use std::hash::Hash;
@@ -24,11 +24,8 @@ pub use types::{Alignment, FmtError, Result, Sign};
 fmtint!(u8 i8 u16 i16 u32 i32 u64 i64 usize isize);
 fmtfloat!(f32 f64);
 
-/// Rust-style format a string given a `HashMap` of the variables.
-pub fn strfmt<K, T: fmt::Display>(fmtstr: &str, vars: &HashMap<K, T>) -> Result<String>
-where
-    K: Hash + Eq + FromStr,
-{
+/// Rust-style format a string given some type of map of the variables.
+pub fn strfmt<K: FromStr, T: fmt::Display, M: Map<Key=K, Out=T>>(fmtstr: &str, vars: M) -> Result<String> {
     let formatter = |mut fmt: Formatter| {
         let k: K = match fmt.key.parse() {
             Ok(k) => k,
@@ -36,7 +33,7 @@ where
                 return Err(new_key_error(fmt.key));
             }
         };
-        let v = match vars.get(&k) {
+        let v = match vars.get_map(&k) {
             Some(v) => v,
             None => {
                 return Err(new_key_error(fmt.key));
@@ -48,25 +45,17 @@ where
 }
 
 pub trait Format {
-    fn format<K, D: fmt::Display>(&self, vars: &HashMap<K, D>) -> Result<String>
-    where
-        K: Hash + Eq + FromStr;
+    fn format<K: FromStr, D: fmt::Display, M: Map<Key=K, Out=D>>(&self, vars: M) -> Result<String>;
 }
 
 impl Format for String {
-    fn format<'a, K, D: fmt::Display>(&self, vars: &HashMap<K, D>) -> Result<String>
-    where
-        K: Hash + Eq + FromStr,
-    {
+    fn format<K: FromStr, D: fmt::Display, M: Map<Key=K, Out=D>>(&self, vars: M) -> Result<String> {
         strfmt(self.as_str(), vars)
     }
 }
 
 impl Format for str {
-    fn format<K, D: fmt::Display>(&self, vars: &HashMap<K, D>) -> Result<String>
-    where
-        K: Hash + Eq + FromStr,
-    {
+    fn format<K: FromStr, D: fmt::Display, M: Map<Key=K, Out=D>>(&self, vars: M) -> Result<String> {
         strfmt(self, vars)
     }
 }
@@ -75,4 +64,34 @@ fn new_key_error(key: &str) -> FmtError {
     let mut msg = String::new();
     write!(msg, "Invalid key: {}", key).unwrap();
     FmtError::KeyError(msg)
+}
+
+pub trait Map {
+   type Key: ?Sized;
+   type Out;
+   fn get_map(&self, k: &Self::Key) -> Option<Self::Out>;
+}
+
+impl<'b, K: Eq + Hash, T> Map for &'b HashMap<K, T> {
+   type Key = K;
+   type Out = &'b T;
+   fn get_map(&self, k: &Self::Key) -> Option<Self::Out>{
+       self.get(k)
+   }
+}
+
+impl<'b, K: Ord, T> Map for &'b BTreeMap<K, T> {
+   type Key = K;
+   type Out = &'b T;
+   fn get_map(&self, k: &Self::Key) -> Option<Self::Out> {
+       self.get(k)
+   }
+}
+
+impl<'b, K: ?Sized, T> Map for &dyn Fn(&K) -> Option<T> {
+   type Key = K;
+   type Out = T;
+   fn get_map(&self, k: &Self::Key) -> Option<Self::Out> {
+       self(k)
+   }
 }


### PR DESCRIPTION
Adds a Map trait instead of HashMap, implemented for HashMap, BTreeMap and &dyn Fn(&K) -> Option<T>

One issue is that because of coherence rules crates can't impl Map for arbitrary structs, like say VecMap.

And I'm still unsure whether trait Map should be 

```
pub trait Map {
   type Key: ?Sized;
   type Out;
   fn get_map(&self, k: &Self::Key) -> Option<Self::Out>;
}
```

or 

```
pub trait Map<K, V> {
   fn get_map(&self, k: K) -> Option<V>;
}
```


