### PR TITLE
Adding message_format inspired macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod types;
 
 #[macro_use]
 mod fmtnum;
+mod macros;
 
 pub use fmtstr::strfmt_map;
 pub use formatter::Formatter;
@@ -121,6 +122,12 @@ impl DisplayStr for String {
 impl DisplayStr for &str {
     fn display_str(&self, f: &mut Formatter) -> Result<()> {
         f.str(self)
+    }
+}
+
+impl DisplayStr for Box<dyn DisplayStr> {
+    fn display_str(&self, f: &mut Formatter) -> Result<()> {
+        self.as_ref().display_str(f)
     }
 }
 /// This trait is effectively an re-implementation for [std::fmt::Display]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ impl DisplayStr for Box<dyn DisplayStr> {
         self.as_ref().display_str(f)
     }
 }
+
 /// This trait is effectively an re-implementation for [std::fmt::Display]
 /// It is used to disguise between the value types that should be formatted
 pub trait DisplayStr {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,48 @@
+/// format a given string with the passed variables
+/// This macro is creating an single used Hashmap, for performance optimizations it might be
+/// more efficient to reuse an existing one.
+///
+/// # Arguments
+/// * `inst` - A string with an Rust-style format instructions
+/// * `values` - A list of values to use for formatting
+///
+/// # Errors
+/// see [strfmt]
+///
+/// # Example
+/// ```
+/// use strfmt::FmtError;
+/// use strfmt::{strfmt,strfmt_builder};
+///
+/// let first = "test";
+/// //test  77.65
+/// println!("{}",strfmt!("{first}{second:7.2}", first,second => 77.6543210).unwrap());
+/// ```
+#[macro_export]
+macro_rules! strfmt {
+    ($inst:expr,$($values:tt)*) =>({
+        use std::collections::HashMap;
+        use $crate::{DisplayStr,strfmt_builder};
+        let mut vars: HashMap<String, Box<dyn DisplayStr>> = HashMap::new();
+        strfmt_builder!(vars,$($values)*);
+        strfmt($inst,&vars)
+    });
+}
+
+#[macro_export]
+macro_rules! strfmt_builder {
+    ($vars:expr,$value:expr) => (
+        $vars.insert(stringify!($value).to_string(),Box::new($value));
+    );
+    ($vars:expr,$name:ident => $value:expr) => {
+        $vars.insert(stringify!($name).to_string(),Box::new($value));
+    };
+    ($vars:expr,$value:expr,$($values:tt)*) => {
+        $vars.insert(stringify!($value).to_string(),Box::new($value));
+        strfmt_builder!($vars,$($values)*)
+    };
+    ($vars:expr,$name:ident => $value:expr,$($values:tt)*) => {
+        $vars.insert(stringify!($name).to_string(),Box::new($value));
+        strfmt_builder!($vars,$($values)*)
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-/// format a given string with the passed variables
+/// Format a given string with the passed variables.
 /// This macro is creating an single used Hashmap, for performance optimizations it might be
 /// more efficient to reuse an existing one.
 ///
@@ -14,9 +14,11 @@
 /// use strfmt::FmtError;
 /// use strfmt::{strfmt,strfmt_builder};
 ///
+/// let fmt = "{first}{second:7.2}";
+/// // ... do stuff and adjust fmt as you need
 /// let first = "test";
 /// //test  77.65
-/// println!("{}",strfmt!("{first}{second:7.2}", first,second => 77.6543210).unwrap());
+/// println!("{}",strfmt!(fmt, first,second => 77.6543210).unwrap());
 /// ```
 #[macro_export]
 macro_rules! strfmt {

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -1,0 +1,17 @@
+///wrap to simulate external use without uses of mod.rs
+mod macro_test{
+    use crate::FmtError;
+    use crate::{strfmt,strfmt_builder};
+
+    #[test]
+    fn test_macros() -> Result<(),FmtError>{
+        let first = "test";
+        let second = 2;
+        assert_eq!("test",strfmt!("{first}", first)?);
+        assert_eq!("test2",strfmt!("{first}{second}", first,second)?);
+        assert_eq!("test77.65  ",strfmt!("{first}{third:<7.2}", first,second, third => 77.6543210)?);
+        assert_eq!("test  77.65",strfmt!("{first}{third:7.2}", first,second, third => 77.6543210)?);
+        Ok(())
+    }
+}
+

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -1,17 +1,22 @@
 ///wrap to simulate external use without uses of mod.rs
-mod macro_test{
+mod macro_test {
     use crate::FmtError;
-    use crate::{strfmt,strfmt_builder};
+    use crate::{strfmt, strfmt_builder};
 
     #[test]
-    fn test_macros() -> Result<(),FmtError>{
+    fn test_macros() -> Result<(), FmtError> {
         let first = "test";
         let second = 2;
-        assert_eq!("test",strfmt!("{first}", first)?);
-        assert_eq!("test2",strfmt!("{first}{second}", first,second)?);
-        assert_eq!("test77.65  ",strfmt!("{first}{third:<7.2}", first,second, third => 77.6543210)?);
-        assert_eq!("test  77.65",strfmt!("{first}{third:7.2}", first,second, third => 77.6543210)?);
+        assert_eq!("test", strfmt!("{first}", first)?);
+        assert_eq!("test2", strfmt!("{first}{second}", first, second)?);
+        assert_eq!(
+            "test77.65  ",
+            strfmt!("{first}{third:<7.2}", first,second, third => 77.6543210)?
+        );
+        assert_eq!(
+            "test  77.65",
+            strfmt!("{first}{third:7.2}", first,second, third => 77.6543210)?
+        );
         Ok(())
     }
 }
-

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod key;
 mod legacy;
 mod strfmt;
 mod test_trait;
+mod macros;
 
 use super::FmtError;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,9 +2,9 @@ mod float;
 mod fmt;
 mod key;
 mod legacy;
+mod macros;
 mod strfmt;
 mod test_trait;
-mod macros;
 
 use super::FmtError;
 


### PR DESCRIPTION
This pull would close #4.

And would allow usage like
``` rust
let first = "test";
//test  77.65
println!("{}",strfmt!("{first}{second:7.2}", first,second => 77.6543210).unwrap());
```
Further, this pull contains a call-passing implementation to allow the original code to work with `Box<DisplayStr>` without any differences. This is used also in the macro to allow mixed-type hashmaps. 

It should be noted that this way boxed allocates heap memory for all values in the vars hashmap