### PR TITLE
Fix alignment for strings containing non-ascii chars

### DIFF
--- a/src/fmtstr.rs
+++ b/src/fmtstr.rs
@@ -112,16 +112,17 @@ impl<'a, 'b> Formatter<'a, 'b> {
         let fill = self.fill();
         let width = self.width();
         let precision = self.precision();
+        let chars_count = s.chars().count();
         // precision will limit length
         let len = match precision {
             Some(p) => {
-                if p < s.chars().count() {
+                if p < chars_count {
                     p
                 } else {
-                    s.chars().count()
+                    chars_count
                 }
             }
-            None => s.chars().count(),
+            None => chars_count,
         };
 
         let mut chars = s.chars();

--- a/src/fmtstr.rs
+++ b/src/fmtstr.rs
@@ -115,13 +115,13 @@ impl<'a, 'b> Formatter<'a, 'b> {
         // precision will limit length
         let len = match precision {
             Some(p) => {
-                if p < s.len() {
+                if p < s.chars().count() {
                     p
                 } else {
-                    s.len()
+                    s.chars().count()
                 }
             }
-            None => s.len(),
+            None => s.chars().count(),
         };
 
         let mut chars = s.chars();

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -59,6 +59,7 @@ fn run_tests<T: fmt::Display>(
 fn test_values() {
     let mut vars: HashMap<String, String> = HashMap::new();
     let too_long = "toooloooong".to_string();
+    let rust_unicode = format!(">{:^7}<", "ಠ_ಠ");
     vars.insert("x".to_string(), "X".to_string());
     vars.insert("long".to_string(), too_long.clone()); // len=10
     vars.insert("hi".to_string(), "hi".to_string());
@@ -80,6 +81,7 @@ fn test_values() {
         (" hi {x:^4}-you rock", " hi  X  -you rock", 0),
         // unicode
         (">{unicode:^7}<", ">  ಠ_ಠ  <", 0),
+        (">{unicode:^7}<", &rust_unicode, 0),
         ("{unicode:<5}", "ಠ_ಠ  ", 0),
         ("{unicode:>5}", "  ಠ_ಠ", 0),
         // fill confusion

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -62,6 +62,7 @@ fn test_values() {
     vars.insert("x".to_string(), "X".to_string());
     vars.insert("long".to_string(), too_long.clone()); // len=10
     vars.insert("hi".to_string(), "hi".to_string());
+    vars.insert("unicode".to_string(), "ಠ_ಠ".to_string());
 
     // format, expected, error
     // error codes: 0 == no error, 1 == Invalid, 2 == KeyError
@@ -77,6 +78,10 @@ fn test_values() {
         // extra text
         (" {x}yz", " Xyz", 0),
         (" hi {x:^4}-you rock", " hi  X  -you rock", 0),
+        // unicode
+        (">{unicode:^7}<", ">  ಠ_ಠ  <", 0),
+        ("{unicode:<5}", "ಠ_ಠ  ", 0),
+        ("{unicode:>5}", "  ಠ_ಠ", 0),
         // fill confusion
         ("{x:10}", "X         ", 0),
         ("{x:>10}", "         X", 0),


### PR DESCRIPTION
I found an issue when I was trying to align some strings with Polish diacritics. This library counts bytes instead of visible characters, so the more non-ascii characters, the shorter alignment was. I fixed it and added short tests for that.