### PR TITLE
Adding DisplayStr impl for &dyn DisplayStr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,12 @@ impl DisplayStr for &str {
     }
 }
 
+impl DisplayStr for &dyn DisplayStr {
+    fn display_str(&self, f: &mut Formatter) -> Result<()> {
+        (*self).display_str(f)
+    }
+}
+
 impl DisplayStr for Box<dyn DisplayStr> {
     fn display_str(&self, f: &mut Formatter) -> Result<()> {
         self.as_ref().display_str(f)

--- a/src/tests/test_trait.rs
+++ b/src/tests/test_trait.rs
@@ -9,3 +9,14 @@ fn test_trait() {
     assert_eq!("hi {x}".format(&vars).unwrap(), "hi X");
     assert_eq!("hi {x}".to_string().format(&vars).unwrap(), "hi X");
 }
+
+#[test]
+fn test_heterogenous_values() {
+    let mut data: HashMap<String, &dyn DisplayStr> = HashMap::new();
+    data.insert("body".to_string(), &"someString");
+    data.insert("some_number".to_string(), &5.0);
+
+    let output = strfmt("{body} = {some_number:2.4}", &data).unwrap();
+
+    assert_eq!(output, "someString = 5.0000");
+}


### PR DESCRIPTION
This is related to https://github.com/vitiral/strfmt/issues/32

The following code would work if &dyn DisplayStr implemented DisplayStr

```rust
    let template = "{body} = {some_number:2.4}";

    let mut data: HashMap<String, &dyn DisplayStr> = HashMap::new();
    data.insert("body".to_string(), &"This is a string");
    data.insert("some_number".to_string(), &5.0);

    let output = strfmt(template, &data)?;
```

A HashMap of &dyn DisplayStr is more efficient than the current best solution for heterogeneous input types, which is Box<dyn DisplayStr>, because each box requires a separate allocation.

Thank you.