### PR TITLE
Changing strfmt_map signature to use FnMut instead of Fn

### DIFF
--- a/src/fmtstr.rs
+++ b/src/fmtstr.rs
@@ -162,10 +162,11 @@ impl<'a, 'b> Formatter<'a, 'b> {
 ///
 /// format a string given the string and a closure that uses
 /// a Formatter
-pub fn strfmt_map<F>(fmtstr: &str, f: &mut F) -> Result<String>
+pub fn strfmt_map<F>(fmtstr: &str, f: F) -> Result<String>
 where
     F: FnMut(Formatter) -> Result<()>,
 {
+    let mut f = f;
     let mut out = String::with_capacity(fmtstr.len() * 2);
     let mut bytes_read: usize = 0;
     let mut opening_brace: usize = 0;

--- a/src/fmtstr.rs
+++ b/src/fmtstr.rs
@@ -162,9 +162,9 @@ impl<'a, 'b> Formatter<'a, 'b> {
 ///
 /// format a string given the string and a closure that uses
 /// a Formatter
-pub fn strfmt_map<F>(fmtstr: &str, f: &F) -> Result<String>
+pub fn strfmt_map<F>(fmtstr: &str, f: &mut F) -> Result<String>
 where
-    F: Fn(Formatter) -> Result<()>,
+    F: FnMut(Formatter) -> Result<()>,
 {
     let mut out = String::with_capacity(fmtstr.len() * 2);
     let mut bytes_read: usize = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn strfmt<'a, K, T: DisplayStr>(fmtstr: &str, vars: &HashMap<K, T>) -> Resul
 where
     K: Hash + Eq + FromStr,
 {
-    let mut formatter = |mut fmt: Formatter| {
+    let formatter = |mut fmt: Formatter| {
         let k: K = match fmt.key.parse() {
             Ok(k) => k,
             Err(_) => {
@@ -69,7 +69,7 @@ where
         };
         v.display_str(&mut fmt)
     };
-    strfmt_map(fmtstr, &mut formatter)
+    strfmt_map(fmtstr, &formatter)
 }
 
 /// Rust-style format a string given a `HashMap` of the variables.
@@ -82,7 +82,7 @@ pub fn strfmt_display<'a, K, T: fmt::Display>(fmtstr: &str, vars: &HashMap<K, T>
 where
     K: Hash + Eq + FromStr,
 {
-    let mut formatter = |mut fmt: Formatter| {
+    let formatter = |mut fmt: Formatter| {
         let k: K = match fmt.key.parse() {
             Ok(k) => k,
             Err(_) => {
@@ -97,7 +97,7 @@ where
         };
         fmt.str(v.to_string().as_str())
     };
-    strfmt_map(fmtstr, &mut formatter)
+    strfmt_map(fmtstr, &formatter)
 }
 
 macro_rules! display_str_impl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn strfmt<'a, K, T: DisplayStr>(fmtstr: &str, vars: &HashMap<K, T>) -> Resul
 where
     K: Hash + Eq + FromStr,
 {
-    let formatter = |mut fmt: Formatter| {
+    let mut formatter = |mut fmt: Formatter| {
         let k: K = match fmt.key.parse() {
             Ok(k) => k,
             Err(_) => {
@@ -69,7 +69,7 @@ where
         };
         v.display_str(&mut fmt)
     };
-    strfmt_map(fmtstr, &formatter)
+    strfmt_map(fmtstr, &mut formatter)
 }
 
 /// Rust-style format a string given a `HashMap` of the variables.
@@ -82,7 +82,7 @@ pub fn strfmt_display<'a, K, T: fmt::Display>(fmtstr: &str, vars: &HashMap<K, T>
 where
     K: Hash + Eq + FromStr,
 {
-    let formatter = |mut fmt: Formatter| {
+    let mut formatter = |mut fmt: Formatter| {
         let k: K = match fmt.key.parse() {
             Ok(k) => k,
             Err(_) => {
@@ -97,7 +97,7 @@ where
         };
         fmt.str(v.to_string().as_str())
     };
-    strfmt_map(fmtstr, &formatter)
+    strfmt_map(fmtstr, &mut formatter)
 }
 
 macro_rules! display_str_impl {

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -193,6 +193,28 @@ fn test_ignore_missing() {
 }
 
 #[test]
+fn test_mut_closure() {
+
+    let mut key_list = vec![];
+    let f = |fmt: Formatter| {
+        match fmt.key.parse::<String>() {
+            Ok(key) => {
+                key_list.push(key);
+            },
+            Err(_) => {
+                return Err(FmtError::KeyError(format!("Invalid key: {}", fmt.key)));
+            }
+        };
+        fmt.skip()
+    };
+
+    let _ = strfmt_map("{one} two {three:4.4}", f).unwrap();
+
+    assert_eq!(key_list, vec!["one", "three"]);
+}
+
+
+#[test]
 fn test_trailing_comma() {
     assert!(strfmt!("{foo}", foo => "bar", ) == Ok("bar".into()));
     let foo = "bar";

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -16,7 +16,7 @@ macro_rules! matches {
 fn run_tests<T: fmt::Display>(
     values: &Vec<(&str, &str, u8)>,
     vars: &HashMap<String, T>,
-    call: &dyn Fn(&str, &HashMap<String, T>) -> Result<String>,
+    call: &mut dyn FnMut(&str, &HashMap<String, T>) -> Result<String>,
 ) {
     for &(fmtstr, expected, expect_err) in values.iter() {
         let result = call(fmtstr, vars);
@@ -140,7 +140,7 @@ fn test_values() {
         ("{x:03}", "00X", 1),
     ];
 
-    run_tests(&values, &vars, &strfmt);
+    run_tests(&values, &vars, &mut strfmt);
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn test_ints_basic() {
         ),
     ];
 
-    run_tests(&values, &vars, &strfmt);
+    run_tests(&values, &vars, &mut strfmt);
 }
 
 #[test]
@@ -181,14 +181,14 @@ fn test_ignore_missing() {
             0,
         ),
     ];
-    let f = |mut fmt: Formatter| match vars.get(fmt.key) {
+    let mut f = |mut fmt: Formatter| match vars.get(fmt.key) {
         Some(v) => fmt.str(v),
         None => fmt.skip(),
     };
 
-    let strfmt_ignore =
-        |fmtstr: &str, vars: &HashMap<String, String>| -> Result<String> { strfmt_map(fmtstr, &f) };
-    run_tests(&values, &vars, &strfmt_ignore);
+    let mut strfmt_ignore =
+        |fmtstr: &str, vars: &HashMap<String, String>| -> Result<String> { strfmt_map(fmtstr, &mut f) };
+    run_tests(&values, &vars, &mut strfmt_ignore);
 }
 
 #[test]
@@ -225,17 +225,17 @@ macro_rules! test_float {
                 // TODO
                 ("{x:+010.2}", "+0042.4242", 1),
             ];
-            let f = |mut fmt: Formatter| {
+            let mut f = |mut fmt: Formatter| {
                 match vars.get(fmt.key) {
                     Some(v) => fmt.$t(*v),
                     None => panic!(),
                 }
             };
 
-            let strfmt_float = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
-                strfmt_map(fmtstr, &f)
+            let mut strfmt_float = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
+                strfmt_map(fmtstr, &mut f)
             };
-            run_tests(&values, &vars, &strfmt_float);
+            run_tests(&values, &vars, &mut strfmt_float);
          }
     )*)
 }
@@ -275,17 +275,17 @@ macro_rules! test_uint {
                 // TODO
                 ("{x:+010}", "+000000042", 1),
             ];
-            let f = |mut fmt: Formatter| {
+            let mut f = |mut fmt: Formatter| {
                 match vars.get(fmt.key) {
                     Some(v) => fmt.$t(*v),
                     None => panic!(),
                 }
             };
 
-            let strfmt_int = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
-                strfmt_map(fmtstr, &f)
+            let mut strfmt_int = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
+                strfmt_map(fmtstr, &mut f)
             };
-            run_tests(&values, &vars, &strfmt_int);
+            run_tests(&values, &vars, &mut strfmt_int);
          }
     )*)
 }
@@ -324,17 +324,17 @@ macro_rules! test_int {
                 // TODO
                 ("{x:+010}", "+000000042", 1),
             ];
-            let f = |mut fmt: Formatter| {
+            let mut f = |mut fmt: Formatter| {
                 match vars.get(fmt.key) {
                     Some(v) => fmt.$t(*v),
                     None => panic!(),
                 }
             };
 
-            let strfmt_uint = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
-                strfmt_map(fmtstr, &f)
+            let mut strfmt_uint = |fmtstr: &str, vars: &HashMap<String, $t>| -> Result<String> {
+                strfmt_map(fmtstr, &mut f)
             };
-            run_tests(&values, &vars, &strfmt_uint);
+            run_tests(&values, &vars, &mut strfmt_uint);
         }
     )*)
 }

--- a/src/tests/strfmt.rs
+++ b/src/tests/strfmt.rs
@@ -188,7 +188,7 @@ fn test_ignore_missing() {
     };
 
     let strfmt_ignore =
-        |fmtstr: &str, vars: &HashMap<String, String>| -> Result<String> { strfmt_map(fmtstr, f) };
+        |fmtstr: &str, vars: &HashMap<String, String>| -> Result<String> { strfmt_map(fmtstr, &f) };
     run_tests(&values, &vars, &strfmt_ignore);
 }
 


### PR DESCRIPTION
I need to get additional information about the format string, such as a list of the keys embedded.  For example:

```rust
        let mut keys = HashSet::new();
        let formatter = |fmt: Formatter| {
            match fmt.key.parse::<String>() {
                Ok(key) => {
                    keys.insert(key);
                },
                Err(_) => {
                    return Err(FmtError::KeyError(format!("Invalid key: {}", fmt.key)));
                }
            };
            fmt.skip()
        };
        let _ = strfmt_map(text, &formatter)?;
```

Unfortunately, `strfmt_map` takes an `Fn` closure.  There is good precedent for other `map` methods to take an `FnMut` closure.  For example, `Iterator::map` https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map

This PR changes the signature of `strfmt_map()` so the above code will compile.

All tests continue to pass with this change.

Thank you.

admin: Resubmitting PR based on dedicated branch instead of forked master, so changes can be merged independently.