### PR TITLE
Modified with trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ authors = ["Garrett Berg <vitiral@gmail.com>"]
 license = "MIT"
 
 [dependencies]
+serde_json = { version = "1.0.105" , optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ mod types;
 mod fmtnum;
 mod macros;
 
+mod maptrait; 
+pub use maptrait::Map; 
+
 pub use fmtstr::strfmt_map;
 pub use formatter::Formatter;
 pub use types::{Alignment, FmtError, Result, Sign};
@@ -50,7 +53,7 @@ fmtfloat!(f32 f64);
 ///
 /// println!("{}", strfmt("{Alpha} {Beta:<5.2}",&my_vars).unwrap());
 /// ```
-pub fn strfmt<'a, K, T: DisplayStr>(fmtstr: &str, vars: &HashMap<K, T>) -> Result<String>
+pub fn strfmt<'a, K, T: DisplayStr>(fmtstr: &str, vars: &impl Map<K, T>) -> Result<String>
 where
     K: Hash + Eq + FromStr,
 {
@@ -61,13 +64,21 @@ where
                 return Err(new_key_error(fmt.key));
             }
         };
-        let v = match vars.get(&k) {
-            Some(v) => v,
-            None => {
-                return Err(new_key_error(fmt.key));
-            }
-        };
-        v.display_str(&mut fmt)
+
+        let v = vars.get(&k);
+        
+        if v.is_some(){
+            return v.unwrap().display_str(&mut fmt); 
+        }
+
+        let v = vars.get_owned(&k);
+
+        if v.is_some(){
+            return v.as_ref().unwrap().display_str(&mut fmt)
+        }
+
+        return Err(new_key_error(fmt.key)); 
+
     };
     strfmt_map(fmtstr, &formatter)
 }
@@ -119,6 +130,13 @@ impl DisplayStr for String {
     }
 }
 
+impl DisplayStr for bool {
+    fn display_str(&self, f: &mut Formatter) -> Result<()> {
+        f.str(self.to_string().as_str())
+    }
+}
+
+
 impl DisplayStr for &str {
     fn display_str(&self, f: &mut Formatter) -> Result<()> {
         f.str(self)
@@ -126,6 +144,13 @@ impl DisplayStr for &str {
 }
 
 impl DisplayStr for &dyn DisplayStr {
+    fn display_str(&self, f: &mut Formatter) -> Result<()> {
+        (*self).display_str(f)
+    }
+}
+
+
+impl <T : DisplayStr> DisplayStr for &T{
     fn display_str(&self, f: &mut Formatter) -> Result<()> {
         (*self).display_str(f)
     }

--- a/src/maptrait.rs
+++ b/src/maptrait.rs
@@ -1,0 +1,33 @@
+use crate::DisplayStr; 
+use std::str::FromStr; 
+use std::hash::Hash; 
+use std::collections::HashMap; 
+
+pub trait Map<K , V> where K: Hash + Eq + FromStr, V: DisplayStr{
+    
+    ///Prioritized first 
+    fn get(&self, key : &K) -> Option<&V>; 
+
+
+    ///Returned an owned item instead of a reference 
+    ///Prioritized second
+    #[allow(unused_variables)]
+    fn get_owned(&self, key : &K) -> Option<V>{
+        None //This is done because HashMap and serde_json Map can both return references  
+    }
+}
+
+impl<K,V> Map<K,V> for HashMap<K,V> where K: Hash + Eq + FromStr, V: DisplayStr {
+    fn get(&self, key : &K) -> Option<&V>{
+        HashMap::get(self, key)
+    }
+}
+
+impl  Map<String, String> for std::env::Vars {
+    fn get(&self, _key : &String) -> Option<&String>{None}
+    fn get_owned(&self, key : &String) -> Option<String>{
+        std::env::var(key).ok()
+    }
+}
+
+mod serde_json_impl; 

--- a/src/maptrait.rs
+++ b/src/maptrait.rs
@@ -30,4 +30,5 @@ impl  Map<String, String> for std::env::Vars {
     }
 }
 
+#[cfg(feature = "serde_json" )]
 mod serde_json_impl; 

--- a/src/maptrait/serde_json_impl.rs
+++ b/src/maptrait/serde_json_impl.rs
@@ -1,0 +1,24 @@
+use crate::Map; 
+extern crate serde_json; 
+use self::serde_json::{ Value, Map as JsonMap};
+use crate::DisplayStr; 
+
+impl Map<String, Value> for JsonMap<String, Value>{
+    fn get(&self, key : &String) -> Option<&Value> {
+        JsonMap::get(self, key)
+    }
+}
+
+
+impl DisplayStr for Value{
+    fn display_str(&self, f: &mut crate::Formatter) -> crate::Result<()> {
+        match self {
+            Value::Bool(b) => b.display_str(f),
+            Value::Null => "null".display_str(f),
+            Value::Number(n) => n.to_string().display_str(f),
+            Value::String(s) => s.display_str(f),
+            Value::Array(a) => format!("{:?}" , a).display_str(f),
+            Value::Object(a) => format!("{:?}", a).display_str(f),
+        }
+    }
+}


### PR DESCRIPTION
Persistent to issue #17 I have modified the implementation of the strfmt function by using a crate-level exported Map trait instead of using a reference to a HashMap 

The Map trait is automatically impleemeneted for `std::collection::HashMap`, `serde_json::Map<String, Value>` and for `std::env::Vars`. For any other custom structs it can be implemented at the user-level 

This is the implementation of the trait 

```rust

pub trait Map<K , V> where K: Hash + Eq + FromStr, V: DisplayStr{
    
    ///Prioritized first 
    fn get(&self, key : &K) -> Option<&V>; 


    ///Returned an owned item instead of a reference 
    ///Prioritized second
    #[allow(unused_variables)]
    fn get_owned(&self, key : &K) -> Option<V>{
        None //This is done because HashMap and serde_json Map can both return references  
    }
}
```  

In general, the `.get()` method is used. However for cases where a local object is created and to be returned for the string-formatting, an object reference cannot be returned since it will be destroyed pursuant Rust's lifetime rules. Hence, in such cases `.get_owned` can be used which will return an owned object and not a reference. 

By default, `.get()` is first tried. If it returns `None`, it tries `.get_owned()`. If both return `None`, then new_key_error is raised 

Additionally, all the tests for this have also passed pursuant to `cargo test` 