### PR TITLE
Isolated import of `crate::strfmt` in macro tests.

### DIFF
--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -1,15 +1,17 @@
 ///wrap to simulate external use without uses of mod.rs
 mod macro_test {
     use crate::FmtError;
-    use crate::strfmt;
 
     #[test]
     fn test_macros() -> Result<(), FmtError> {
         let first = "test";
         let second = 2;
         // Note: some use strfmt with crate:: and some don't on purpose.
-        assert_eq!("test", strfmt!("{first}", first)?);
-        assert_eq!("test2", strfmt!("{first}{second}", first, second)?);
+        {
+            use crate::strfmt;
+            assert_eq!("test", strfmt!("{first}", first)?);
+            assert_eq!("test2", strfmt!("{first}{second}", first, second)?);
+        }
         assert_eq!(
             "test77.65  ",
             crate::strfmt!("{first}{third:<7.2}", first,second, third => 77.6543210)?


### PR DESCRIPTION
In the tests, you couldn't properly test the explicit path version because `strfmt!` was already in scope. So I isolated it to the scope where the imported version is used.